### PR TITLE
minor: update node-sass dependencyu to work with node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "jest": "^23.4.2",
     "mini-css-extract-plugin": "^0.4.0",
     "mocha": "^5.2.0",
-    "node-sass": "^4.9.3",
+    "node-sass": "^4.12.0",
     "optimize-css-assets-webpack-plugin": "^4.0.1",
     "ora": "^2.1.0",
     "postcss-import": "^11.1.0",


### PR DESCRIPTION
Whilst trying to build on my linux machine, I find that node-sass attempts to build, and fails, against node v12.

See: https://stackoverflow.com/a/57271773/1697008

This PR _only_ updates the node-sass dependency. There's a pre-built binding for v12, so there's not even a need for the client to build.