### PR TITLE
feature: log current playing track

### DIFF
--- a/src/common/store/config/types.ts
+++ b/src/common/store/config/types.ts
@@ -28,6 +28,7 @@ export interface AppConfig {
   crashReports: boolean;
   downloadPath: string;
   showTrackChangeNotification: boolean;
+  logTrackChange: boolean;
   overrideClientId: string | null;
   theme: string;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,7 @@ export const CONFIG = {
       theme: ThemeKeys.darkBlue,
       downloadPath,
       showTrackChangeNotification: true,
+      logTrackChange: false,
       overrideClientId: null
     }
   }

--- a/src/main/features/core/notificationManager.ts
+++ b/src/main/features/core/notificationManager.ts
@@ -5,6 +5,8 @@ import { PlayingTrack } from '@common/store/player';
 import { SC } from '@common/utils';
 import { Auryo } from '@main/app';
 import { Feature } from '../feature';
+import { settings } from '../../settings';
+import fs from 'fs';
 
 export default class NotificationManager extends Feature {
   public readonly featureName = 'NotificationManager';
@@ -15,10 +17,6 @@ export default class NotificationManager extends Feature {
   public register() {
     // Track changed
     this.subscribe<PlayingTrack>(['player', 'playingTrack'], ({ currentState }) => {
-      if (!this.win || (this.win && this.win.isFocused())) {
-        return;
-      }
-
       const {
         player: { playingTrack },
         config: {
@@ -26,16 +24,25 @@ export default class NotificationManager extends Feature {
         }
       } = currentState;
 
-      if (playingTrack && showTrackChangeNotification) {
+      if (playingTrack) {
         const trackId = playingTrack.id;
         const track = getTrackEntity(trackId)(currentState);
+        
+        if (settings.get('app.logTrackChange')){
+          fs.writeFileSync('/tmp/auryo_status.log', track.title + "\n" + track.user.username);
+        };
 
-        if (track) {
-          this.sendToWebContents(EVENTS.APP.SEND_NOTIFICATION, {
-            title: track.title,
-            message: `${track.user && track.user.username ? track.user.username : ''}`,
-            image: SC.getImageUrl(track, IMAGE_SIZES.SMALL)
-          });
+        if (!this.win || (this.win && this.win.isFocused())) {
+          return;
+        }
+        if (showTrackChangeNotification){
+          if (track) {
+              this.sendToWebContents(EVENTS.APP.SEND_NOTIFICATION, {
+                title: track.title,
+                message: `${track.user && track.user.username ? track.user.username : ''}`,
+                image: SC.getImageUrl(track, IMAGE_SIZES.SMALL)
+              });
+            }
         }
       }
     });

--- a/src/main/features/core/notificationManager.ts
+++ b/src/main/features/core/notificationManager.ts
@@ -27,22 +27,22 @@ export default class NotificationManager extends Feature {
       if (playingTrack) {
         const trackId = playingTrack.id;
         const track = getTrackEntity(trackId)(currentState);
-        
-        if (settings.get('app.logTrackChange')){
-          fs.writeFileSync('/tmp/auryo_status.log', track.title + "\n" + track.user.username);
-        };
+
+        if (settings.get('app.logTrackChange')) {
+          fs.writeFileSync('/tmp/auryo_status.log', `${track?.title}\n${track?.user?.username}`);
+        }
 
         if (!this.win || (this.win && this.win.isFocused())) {
           return;
         }
-        if (showTrackChangeNotification){
+        if (showTrackChangeNotification) {
           if (track) {
-              this.sendToWebContents(EVENTS.APP.SEND_NOTIFICATION, {
-                title: track.title,
-                message: `${track.user && track.user.username ? track.user.username : ''}`,
-                image: SC.getImageUrl(track, IMAGE_SIZES.SMALL)
-              });
-            }
+            this.sendToWebContents(EVENTS.APP.SEND_NOTIFICATION, {
+              title: track.title,
+              message: `${track.user && track.user.username ? track.user.username : ''}`,
+              image: SC.getImageUrl(track, IMAGE_SIZES.SMALL)
+            });
+          }
         }
       }
     });

--- a/src/renderer/pages/settings/Settings.tsx
+++ b/src/renderer/pages/settings/Settings.tsx
@@ -129,6 +129,18 @@ class Settings extends React.PureComponent<AllProps, State> {
           {
             authenticated: true,
             setting: (
+              <CheckboxConfig
+                key="logTrackChange"
+                name="Log current playing track to /tmp/auryo_track.log"
+                configKey="app.logTrackChange"
+                config={config}
+                setConfigKey={setConfigKey}
+              />
+            )
+          },
+          {
+            authenticated: true,
+            setting: (
               <SelectConfig
                 key="theme"
                 name="Theme"


### PR DESCRIPTION
It logs current playing track and artist name to `/tmp/auryo_status.log`
Also added a new setting, so users can turn it up if they want to use. Comes disabled by default.

![05-01_17-57-30](https://user-images.githubusercontent.com/24779257/80814849-4c24da80-8bd5-11ea-879f-b272c36d22f1.png)
![05-01_17-58-46](https://user-images.githubusercontent.com/24779257/80815104-b473bc00-8bd5-11ea-8b0d-5d734bb19a02.png)
